### PR TITLE
Some cleanup and additional tests of orbit-integration kicks

### DIFF
--- a/galpy/util/bovy_coords.py
+++ b/galpy/util/bovy_coords.py
@@ -909,11 +909,7 @@ def rect_to_cyl(X,Y,Z):
 
     """
     R= sc.sqrt(X**2.+Y**2.)
-    phi= sc.arcsin(Y/R)
-    if isinstance(X,float) and X < 0.:
-        phi= m.pi-phi
-    elif isinstance(X,sc.ndarray):
-        phi[(X < 0.)]= m.pi-phi[(X < 0.)]
+    phi= sc.arctan2(Y,X)
     return (R,phi,Z)
 
 def cyl_to_rect(R,phi,Z):

--- a/nose/test_streamgapdf.py
+++ b/nose/test_streamgapdf.py
@@ -356,10 +356,9 @@ def test_hernquistX_unity():
     return None
 
 # Test general impulse vs. integrating orbital time-samples
-def test_impulse_deltav_general_curved():
+def test_impulse_deltav_general_acceleration():
     from galpy.df_src import streamgapdf
     from galpy.potential import PlummerPotential
-    from galpy.df_src import streamgapdf
     tol= -3.
     tmax=30.
     dt=0.01
@@ -420,7 +419,6 @@ def test_impulse_deltav_general_curved():
 def test_impulse_deltav_general_orbit():
     from galpy.df_src import streamgapdf
     from galpy.potential import PlummerPotential, LogarithmicHaloPotential
-    from galpy.df_src import streamgapdf
     tol= -10.
     rcurv=10.
     vp=220.


### PR DESCRIPTION
I cleaned up the code for the orbit-integration kicks slightly and added a test using a fake zero-force galpy Potential.

It's not clear to me that the _acceleration kick method is that useful? Doesn't it do the same as the _orbitintegration one, except that you have to first do the orbit integration yourself? My new test covers the _orbitintegration function, so I think you could remove the _acceleration one and the tests that use it?

I'll hold off on merging your pull request into galpy until you finish the fully general case?
