### PR TITLE
Additional test of _orbitintegration vs. _fullplummerintegration and some other test tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,7 @@ install:
  - easy_install --upgrade requests
  - easy_install --upgrade coveralls
  - pip install codecov
-#cda64c8ac9fa59b83663b155d14d184eb33826a5
- - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git@60485bbf1ff77a3834b06091df04abb384fdc797; fi
+ - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git; fi
  - python setup.py build_ext --coverage --single_ext --inplace
  - python setup.py develop --single_ext
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ install:
  - easy_install --upgrade requests
  - easy_install --upgrade coveralls
  - pip install codecov
- - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git@cda64c8ac9fa59b83663b155d14d184eb33826a5; fi
+#cda64c8ac9fa59b83663b155d14d184eb33826a5
+ - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git@53dcd5b1243a8b; fi
  - python setup.py build_ext --coverage --single_ext --inplace
  - python setup.py develop --single_ext
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ install:
  - gem install coveralls-lcov
  - easy_install --upgrade requests
  - easy_install --upgrade coveralls
- - pip install codecov
  - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git; fi
  - python setup.py build_ext --coverage --single_ext --inplace
  - python setup.py develop --single_ext
@@ -57,7 +56,6 @@ after_success:
  # Generate lcov output 
  - lcov --capture --base-directory . --directory build/temp.linux-x86_64-2.7/galpy/ --output-file coverage.info
  # Codecov
- - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then codecov; fi
  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then bash <(curl -s https://codecov.io/bash) -v; fi
  # coveralls: combine, generate json, and upload
  - coveralls-lcov -v -n coverage.info > coverage.c.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
  - easy_install --upgrade coveralls
  - pip install codecov
 #cda64c8ac9fa59b83663b155d14d184eb33826a5
- - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git@53dcd5b1243a8b; fi
+ - if $REQUIRES_PYNBODY; then pip install git+git://github.com/pynbody/pynbody.git@60485bbf1ff77a3834b06091df04abb384fdc797; fi
  - python setup.py build_ext --coverage --single_ext --inplace
  - python setup.py develop --single_ext
 script:

--- a/nose/test_orbit.py
+++ b/nose/test_orbit.py
@@ -1254,7 +1254,7 @@ def test_fixedstepsize():
                 runtimes[ii]= time.time()-start
             for ii,mult in enumerate(mults):
                 if ii == 0: continue
-                assert numpy.fabs(runtimes[ii]/runtimes[0]/mults[ii]*mults[0]-1.) < 0.3, 'Runtime of integration with fixed stepsize for integrator %s, type or orbit %s, stepsize reduction %i is not %i times less (residual is %g, times %g and %g)' % (integrator,type,mults[ii],mults[ii],
+                assert numpy.fabs(runtimes[ii]/runtimes[0]/mults[ii]*mults[0]-1.) < 0.4, 'Runtime of integration with fixed stepsize for integrator %s, type or orbit %s, stepsize reduction %i is not %i times less (residual is %g, times %g and %g)' % (integrator,type,mults[ii],mults[ii],
 numpy.fabs(runtimes[ii]/runtimes[0]/mults[ii]*mults[0]-1.),mults[ii]/mults[0],runtimes[ii]/runtimes[0])
     return None
 

--- a/nose/test_streamgapdf.py
+++ b/nose/test_streamgapdf.py
@@ -427,15 +427,14 @@ def test_impulse_deltav_general_orbit_zeroforce():
 # Test general impulse vs. full stream and halo integration for zero force
 def test_impulse_deltav_general_fullintegration_zeroforce():
     from galpy.df_src import streamgapdf
-    from galpy.potential import PlummerPotential
-    tol= -4.
+    tol= -3.
     rcurv=10.
     vp=220.
     GM=1.5
     rs=4.
     x0 = numpy.array([rcurv,0.,0.])
     v0 = numpy.array([0.,vp,0.])
-    w = numpy.array([1.,numpy.pi/2.,0.])
+    w = numpy.array([1.,numpy.pi/4.*vp,0.])
     plummer_kick= streamgapdf.impulse_deltav_plummer_curvedstream(\
         v0,
         x0,
@@ -455,12 +454,15 @@ def test_impulse_deltav_general_fullintegration_zeroforce():
         galpot,
         GM,
         rs,
-        tmaxfac=10.,
+        tmaxfac=100.,
         N=1000)
-    assert numpy.all(numpy.fabs(orbit_kick-plummer_kick) < 10.**tol), \
+    nzeroIndx= numpy.fabs(plummer_kick) > 10.**tol
+    assert numpy.all(numpy.fabs((orbit_kick-plummer_kick)/plummer_kick)[nzeroIndx] < 10.**tol), \
+        'general kick with acceleration calculation does not agree with Plummer calculation for a Plummer potential, for straight'
+    assert numpy.all(numpy.fabs(orbit_kick-plummer_kick)[True-nzeroIndx] < 10.**tol), \
         'general kick with acceleration calculation does not agree with Plummer calculation for a Plummer potential, for straight'
     # Same for a bunch of positions
-    tol= -4.
+    tol= -2.5
     GM=numpy.pi
     rs=numpy.exp(1.)
     theta = numpy.linspace(-numpy.pi/4.,numpy.pi/4.,10)
@@ -490,9 +492,12 @@ def test_impulse_deltav_general_fullintegration_zeroforce():
         galpot,
         GM,
         rs,
-        tmaxfac=20.)
-    assert numpy.all(numpy.fabs(orbit_kick-plummer_kick) < 10.**tol), \
-            'full stream+halo integration calculation does not agree with Plummer calculation for a Plummer potential, for curved stream'
+        tmaxfac=100.)
+    nzeroIndx= numpy.fabs(plummer_kick) > 10.**tol
+    assert numpy.all(numpy.fabs((orbit_kick-plummer_kick)/plummer_kick)[nzeroIndx] < 10.**tol), \
+        'full stream+halo integration calculation does not agree with Plummer calculation for a Plummer potential, for curved stream'
+    assert numpy.all(numpy.fabs(orbit_kick-plummer_kick)[True-nzeroIndx] < 10.**tol), \
+        'full stream+halo integration calculation does not agree with Plummer calculation for a Plummer potential, for curved stream'
     return None
 
 # Test general impulse vs. full stream and halo integration for fast encounter

--- a/nose/test_streamgapdf.py
+++ b/nose/test_streamgapdf.py
@@ -366,28 +366,14 @@ def test_impulse_deltav_general_orbit_zeroforce():
     v0 = numpy.array([0.,vp,0.])
     w = numpy.array([1.,numpy.pi/2.,0.])
     plummer_kick= streamgapdf.impulse_deltav_plummer_curvedstream(\
-        v0,
-        x0,
-        3.,
-        w,
-        x0,
-        v0,
-        1.5,4.)
+        v0,x0,3.,w,x0,v0,1.5,4.)
     pp= PlummerPotential(amp=1.5,b=4.)
     vang=vp/rcurv
     angrange=numpy.pi
     maxt=5.*angrange/vang
     galpot = constantPotential()
     orbit_kick= streamgapdf.impulse_deltav_general_orbitintegration(\
-        v0,
-        x0,
-        3.,
-        w,
-        x0,
-        v0,
-        pp,
-        maxt,
-        galpot)
+        v0,x0,3.,w,x0,v0,pp,maxt,galpot)
     assert numpy.all(numpy.fabs(orbit_kick-plummer_kick) < 10.**tol), \
         'general kick with acceleration calculation does not agree with Plummer calculation for a Plummer potential, for straight'
     # Same for a bunch of positions
@@ -403,21 +389,9 @@ def test_impulse_deltav_general_orbit_zeroforce():
     V[:,0]=vx
     V[:,1]=vy
     plummer_kick= streamgapdf.impulse_deltav_plummer_curvedstream(\
-        V,
-        Xc,
-        3.,
-        w,
-        x0,
-        v0,
-        numpy.pi,numpy.exp(1.))
+        V,Xc,3.,w,x0,v0,numpy.pi,numpy.exp(1.))
     orbit_kick=streamgapdf.impulse_deltav_general_orbitintegration(\
-        V,
-        Xc,
-        3.,
-        w,
-        x0,
-        v0,
-        pp,
+        V,Xc,3.,w,x0,v0,pp,
         maxt,
         galpot)
     assert numpy.all(numpy.fabs(orbit_kick-plummer_kick) < 10.**tol), \
@@ -436,26 +410,10 @@ def test_impulse_deltav_general_fullintegration_zeroforce():
     v0 = numpy.array([0.,vp,0.])
     w = numpy.array([1.,numpy.pi/4.*vp,0.])
     plummer_kick= streamgapdf.impulse_deltav_plummer_curvedstream(\
-        v0,
-        x0,
-        3.,
-        w,
-        x0,
-        v0,
-        GM,rs)
+        v0,x0,3.,w,x0,v0,GM,rs)
     galpot = constantPotential()
     orbit_kick= streamgapdf.impulse_deltav_general_fullplummerintegration(\
-        v0,
-        x0,
-        3.,
-        w,
-        x0,
-        v0,
-        galpot,
-        GM,
-        rs,
-        tmaxfac=100.,
-        N=1000)
+        v0,x0,3.,w,x0,v0,galpot,GM,rs,tmaxfac=100.,N=1000)
     nzeroIndx= numpy.fabs(plummer_kick) > 10.**tol
     assert numpy.all(numpy.fabs((orbit_kick-plummer_kick)/plummer_kick)[nzeroIndx] < 10.**tol), \
         'general kick with acceleration calculation does not agree with Plummer calculation for a Plummer potential, for straight'
@@ -475,24 +433,9 @@ def test_impulse_deltav_general_fullintegration_zeroforce():
     V[:,0]=vx
     V[:,1]=vy
     plummer_kick= streamgapdf.impulse_deltav_plummer_curvedstream(\
-        V,
-        Xc,
-        3.,
-        w,
-        x0,
-        v0,
-        GM,rs)
+        V,Xc,3.,w,x0,v0,GM,rs)
     orbit_kick=streamgapdf.impulse_deltav_general_fullplummerintegration(\
-        V,
-        Xc,
-        3.,
-        w,
-        x0,
-        v0,
-        galpot,
-        GM,
-        rs,
-        tmaxfac=100.)
+        V,Xc,3.,w,x0,v0,galpot,GM,rs,tmaxfac=100.)
     nzeroIndx= numpy.fabs(plummer_kick) > 10.**tol
     assert numpy.all(numpy.fabs((orbit_kick-plummer_kick)/plummer_kick)[nzeroIndx] < 10.**tol), \
         'full stream+halo integration calculation does not agree with Plummer calculation for a Plummer potential, for curved stream'
@@ -513,27 +456,9 @@ def test_impulse_deltav_general_fullintegration_fastencounter():
     lp= LogarithmicHaloPotential(normalize=1.)
     pp= PlummerPotential(amp=GM,b=rs)
     orbit_kick= streamgapdf.impulse_deltav_general_orbitintegration(\
-        v0,
-        x0,
-        3.,
-        w,
-        x0,
-        v0,
-        pp,
-        5.*numpy.pi,
-        lp)
+        v0,x0,3.,w,x0,v0,pp,5.*numpy.pi,lp)
     full_kick= streamgapdf.impulse_deltav_general_fullplummerintegration(\
-        v0,
-        x0,
-        3.,
-        w,
-        x0,
-        v0,
-        lp,
-        GM,
-        rs,
-        tmaxfac=10.,
-        N=1000)
+        v0,x0,3.,w,x0,v0,lp,GM,rs,tmaxfac=10.,N=1000)
     # Kick should be in the X direction
     assert numpy.fabs((orbit_kick-full_kick)/full_kick)[0,0] < 10.**tol, \
         'Acceleration kick does not agree with full-orbit-integration kick for fast encounter'

--- a/nose/test_streamgapdf.py
+++ b/nose/test_streamgapdf.py
@@ -495,6 +495,47 @@ def test_impulse_deltav_general_fullintegration_zeroforce():
             'full stream+halo integration calculation does not agree with Plummer calculation for a Plummer potential, for curved stream'
     return None
 
+# Test general impulse vs. full stream and halo integration for fast encounter
+def test_impulse_deltav_general_fullintegration_fastencounter():
+    from galpy.df_src import streamgapdf
+    from galpy.potential import PlummerPotential, LogarithmicHaloPotential
+    tol= -2.
+    GM=1.5
+    rs=4.
+    x0 = numpy.array([1.5,0.,0.])
+    v0 = numpy.array([0.,1.,0.]) #circular orbit
+    w = numpy.array([0.,0.,100.]) # very fast compared to v=1
+    lp= LogarithmicHaloPotential(normalize=1.)
+    pp= PlummerPotential(amp=GM,b=rs)
+    orbit_kick= streamgapdf.impulse_deltav_general_orbitintegration(\
+        v0,
+        x0,
+        3.,
+        w,
+        x0,
+        v0,
+        pp,
+        5.*numpy.pi,
+        lp)
+    full_kick= streamgapdf.impulse_deltav_general_fullplummerintegration(\
+        v0,
+        x0,
+        3.,
+        w,
+        x0,
+        v0,
+        lp,
+        GM,
+        rs,
+        tmaxfac=10.,
+        N=1000)
+    # Kick should be in the X direction
+    assert numpy.fabs((orbit_kick-full_kick)/full_kick)[0,0] < 10.**tol, \
+        'Acceleration kick does not agree with full-orbit-integration kick for fast encounter'
+    assert numpy.all(numpy.fabs((orbit_kick-full_kick))[0,1:] < 10.**tol), \
+        'Acceleration kick does not agree with full-orbit-integration kick for fast encounter'
+    return None
+
 from galpy.potential import Potential
 class constantPotential(Potential):
     def __init__(self):


### PR DESCRIPTION
I added another test comparing the _orbitintegration routine to _fullplummerintegration for a very fast moving halo (so the two should pretty much be equivalent, because the subhalo moves on an approx. straight line). Seems to work fine and I looked through the code for both of these functions and that all looks good to me. No idea why you're seeing the big difference for these two in the plot for the paper, must be due to the subhalo orbit I guess.

I also merged in master, which has an improvement in the orbit test that keeps failing.
